### PR TITLE
Fix for DllMain() initialization deadlock

### DIFF
--- a/include/stxxl/bits/common/mutex.h
+++ b/include/stxxl/bits/common/mutex.h
@@ -37,17 +37,11 @@
 
 STXXL_BEGIN_NAMESPACE
 
+
+
 #if STXXL_STD_THREADS
 
-#if STXXL_STD_THREADS && STXXL_WINDOWS && STXXL_MSVC >= 1700
-	
-	class spinLock;
-	typedef spinLock fastmutex;
-#else
 
-	typedef std::mutex fastmutex;
-
-#endif
 typedef std::mutex mutex;
 
 #elif STXXL_BOOST_THREADS
@@ -104,6 +98,16 @@ public:
 };
 
 #endif
+#if STXXL_STD_THREADS && STXXL_WINDOWS && STXXL_MSVC >= 1700
+
+class spinLock;
+typedef spinLock fastmutex;
+#else
+
+typedef mutex fastmutex;
+
+#endif
+
 
 #if STXXL_STD_THREADS
 
@@ -113,6 +117,7 @@ typedef std::unique_lock<fastmutex> scoped_fast_mutex_lock;
 #elif STXXL_BOOST_THREADS
 
 typedef boost::mutex::scoped_lock scoped_mutex_lock;
+typedef boost::mutex::scoped_lock scoped_fast_mutex_lock;
 
 #else
 
@@ -153,6 +158,7 @@ public:
 };
 
 #endif
+
 
 #if STXXL_STD_THREADS && STXXL_WINDOWS && STXXL_MSVC >= 1700
 

--- a/include/stxxl/bits/common/mutex.h
+++ b/include/stxxl/bits/common/mutex.h
@@ -156,7 +156,7 @@ public:
         return m_mutex.native_handle();
     }
 };
-
+typedef scoped_mutex_lock scoped_fast_mutex_lock;
 #endif
 
 

--- a/include/stxxl/bits/common/mutex.h
+++ b/include/stxxl/bits/common/mutex.h
@@ -18,6 +18,10 @@
 #include <stxxl/bits/config.h>
 #include <stxxl/bits/namespace.h>
 
+#if STXXL_STD_THREADS && STXXL_WINDOWS && STXXL_MSVC >= 1700
+#include <atomic>
+#endif
+
 #if STXXL_STD_THREADS
  #include <mutex>
 #elif STXXL_BOOST_THREADS
@@ -35,6 +39,15 @@ STXXL_BEGIN_NAMESPACE
 
 #if STXXL_STD_THREADS
 
+#if STXXL_STD_THREADS && STXXL_WINDOWS && STXXL_MSVC >= 1700
+	
+	class spinLock;
+	typedef spinLock fastmutex;
+#else
+
+	typedef std::mutex fastmutex;
+
+#endif
 typedef std::mutex mutex;
 
 #elif STXXL_BOOST_THREADS
@@ -95,6 +108,7 @@ public:
 #if STXXL_STD_THREADS
 
 typedef std::unique_lock<std::mutex> scoped_mutex_lock;
+typedef std::unique_lock<fastmutex> scoped_fast_mutex_lock;
 
 #elif STXXL_BOOST_THREADS
 
@@ -140,6 +154,44 @@ public:
 
 #endif
 
+#if STXXL_STD_THREADS && STXXL_WINDOWS && STXXL_MSVC >= 1700
+
+class spinLock
+{
+public:
+#if STXXL_MSVC < 1800
+	spinLock()
+	{
+		lck.clear(std::memory_order_release);
+	}
+#endif
+
+	void lock()
+	{
+		while(lck.test_and_set(std::memory_order_acquire))
+		{}
+	}
+
+	void unlock()
+	{
+		lck.clear(std::memory_order_release);
+	}
+
+private:
+#if STXXL_MSVC >= 1800
+	std::atomic_flag lck = ATOMIC_FLAG_INIT;
+	spinLock(const spinLock&) =delete;
+	spinLock& operator=(const spinLock&) =delete;
+#else
+	std::atomic_flag lck;
+	spinLock(const spinLock&);
+	spinLock& operator=(const spinLock&);
+#endif
+};
+
+
+
+#endif
 STXXL_END_NAMESPACE
 
 #endif // !STXXL_COMMON_MUTEX_HEADER

--- a/include/stxxl/bits/mng/disk_allocator.h
+++ b/include/stxxl/bits/mng/disk_allocator.h
@@ -6,7 +6,7 @@
  *  Copyright (C) 2002-2004 Roman Dementiev <dementiev@mpi-sb.mpg.de>
  *  Copyright (C) 2007 Johannes Singler <singler@ira.uka.de>
  *  Copyright (C) 2009, 2010 Andreas Beckmann <beckmann@cs.uni-frankfurt.de>
- *  Copyright (C) 2013 Timo Bingmann <tb@panthema.net>
+ *  Copyright (C) 2013-2015 Timo Bingmann <tb@panthema.net>
  *
  *  Distributed under the Boost Software License, Version 1.0.
  *  (See accompanying file LICENSE_1_0.txt or copy at
@@ -18,6 +18,8 @@
 
 #include <stxxl/bits/common/mutex.h>
 #include <stxxl/bits/common/types.h>
+#include <stxxl/bits/common/exceptions.h>
+#include <stxxl/bits/common/error_handling.h>
 #include <stxxl/bits/io/file.h>
 #include <stxxl/bits/mng/bid.h>
 #include <stxxl/bits/mng/config.h>


### PR DESCRIPTION
[Only affects Windows - Visual Studio configuration]

In the scenario when stxxl is being initialized in an DllMain() the application may or may mot deadlock, this patch fixes that.
