### PR TITLE
Fix possible compiler errors on Windows / Microsoft Visual C++

### DIFF
--- a/lib/io/wfs_file_base.cpp
+++ b/lib/io/wfs_file_base.cpp
@@ -87,7 +87,7 @@ static HANDLE open_file_impl(const std::string& filename, int mode)
         // ignored
     }
 
-    HANDLE file_des = ::CreateFile(filename.c_str(), dwDesiredAccess, dwShareMode, NULL,
+    HANDLE file_des = ::CreateFileA(filename.c_str(), dwDesiredAccess, dwShareMode, NULL,
                                    dwCreationDisposition, dwFlagsAndAttributes, NULL);
 
     if (file_des != INVALID_HANDLE_VALUE)
@@ -100,7 +100,7 @@ static HANDLE open_file_impl(const std::string& filename, int mode)
 
         dwFlagsAndAttributes &= ~FILE_FLAG_NO_BUFFERING;
 
-        HANDLE file_des = ::CreateFile(filename.c_str(), dwDesiredAccess, dwShareMode, NULL,
+        HANDLE file_des = ::CreateFileA(filename.c_str(), dwDesiredAccess, dwShareMode, NULL,
                                        dwCreationDisposition, dwFlagsAndAttributes, NULL);
 
         if (file_des != INVALID_HANDLE_VALUE)
@@ -125,18 +125,18 @@ wfs_file_base::wfs_file_base(
     if (!(mode_ & RDONLY) && (mode & DIRECT))
     {
         char buf[32768], * part;
-        if (!GetFullPathName(filename.c_str(), sizeof(buf), buf, &part))
+        if (!GetFullPathNameA(filename.c_str(), sizeof(buf), buf, &part))
         {
-            STXXL_ERRMSG("wfs_file_base::wfs_file_base(): GetFullPathName() error for file " << filename);
+            STXXL_ERRMSG("wfs_file_base::wfs_file_base(): GetFullPathNameA() error for file " << filename);
             bytes_per_sector = 512;
         }
         else
         {
             part[0] = char();
             DWORD bytes_per_sector_;
-            if (!GetDiskFreeSpace(buf, NULL, &bytes_per_sector_, NULL, NULL))
+            if (!GetDiskFreeSpaceA(buf, NULL, &bytes_per_sector_, NULL, NULL))
             {
-                STXXL_ERRMSG("wfs_file_base::wfs_file_base(): GetDiskFreeSpace() error for path " << buf);
+                STXXL_ERRMSG("wfs_file_base::wfs_file_base(): GetDiskFreeSpaceA() error for path " << buf);
                 bytes_per_sector = 512;
             }
             else
@@ -231,7 +231,7 @@ void wfs_file_base::set_size(offset_type newsize)
 void wfs_file_base::close_remove()
 {
     close();
-    ::DeleteFile(filename.c_str());
+    ::DeleteFileA(filename.c_str());
 }
 
 STXXL_END_NAMESPACE

--- a/lib/mng/config.cpp
+++ b/lib/mng/config.cpp
@@ -127,8 +127,8 @@ void config::load_default_config()
     entry1.autogrow = true;
 
     char* tmpstr = new char[255];
-    if (GetTempPath(255, tmpstr) == 0)
-        STXXL_THROW_WIN_LASTERROR(resource_error, "GetTempPath()");
+    if (GetTempPathA(255, tmpstr) == 0)
+        STXXL_THROW_WIN_LASTERROR(resource_error, "GetTempPathA()");
     entry1.path = tmpstr;
     entry1.path += "stxxl.tmp";
     delete[] tmpstr;


### PR DESCRIPTION
For example GetTempPath may be #defined as GetTempPathA (narrow chars) or GetTempPathW (wide chars). Because the present code doesn't work with GetTempPathW, let's use GetTempPathA explicitly.

The same applies also to some other WinAPI functions that are used in wfs_file_base.cpp. Fixed these too.