### PR TITLE
compile fix with g++ 5.3.0

### DIFF
--- a/tools/benchmark_files.cpp
+++ b/tools/benchmark_files.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <iomanip>
+#include <cstring>
 #include <vector>
 
 #include <stxxl/io>


### PR DESCRIPTION
At least in one configuration *stxxl* fails to compile with *g++ 5.3.0* on *Gentoo*.
Since the fix is trivial and safe I didn't dig in **exactly which** configuration it fails.

The declaration for `strrchr` isn't known in the file  `tools/benchmark_files.cpp`. Including `<cstring>` fixes it.