### PR TITLE
 Add a default C'tor for spin_lock when MSVC_VER>1800

### DIFF
--- a/include/stxxl/bits/common/mutex.h
+++ b/include/stxxl/bits/common/mutex.h
@@ -169,6 +169,9 @@ public:
     {
         lck.clear(std::memory_order_release);
     }
+#else
+    spin_lock()
+    { }
 #endif
 
     void lock()


### PR DESCRIPTION
Fix https://github.com/stxxl/stxxl/issues/18

* Based on https://github.com/alex85k/stxxl/commit/691c3e22f76a9a85b393407f628f61472b9868fe
* See https://github.com/stxxl/stxxl/issues/18 for more info