### PR TITLE
Fix #38: `empty()` actually returns `!empty()`

### DIFF
--- a/include/stxxl/bits/containers/hash_map/hash_map.h
+++ b/include/stxxl/bits/containers/hash_map/hash_map.h
@@ -295,7 +295,7 @@ public:
     //! Check if container is empty.
     bool empty() const
     {
-        return size() != 0;
+        return size() == 0;
     }
 
     /*!


### PR DESCRIPTION
See #38