### PR TITLE
Removes variable name hiding by renaming variables with the same name in a nested scope.

### DIFF
--- a/lib/algo/async_schedule.cpp
+++ b/lib/algo/async_schedule.cpp
@@ -112,8 +112,8 @@ int_type simulate_async_write(
         if (oldtime != cur.timestamp)
         {
             // clear disk_busy
-            for (int_type i = 0; i <= D; i++)
-                disk_busy[i] = false;
+            for (int_type j = 0; j <= D; j++)
+                disk_busy[j] = false;
 
             oldtime = cur.timestamp;
         }
@@ -157,8 +157,8 @@ int_type simulate_async_write(
     }
 
     assert(i == -1);
-    for (int_type i = 0; i <= D; i++)
-        assert(disk_queues[i].empty());
+    for (int_type j = 0; j <= D; j++)
+        assert(disk_queues[j].empty());
 
     return (oldtime - 1);
 }

--- a/lib/io/iostats.cpp
+++ b/lib/io/iostats.cpp
@@ -288,16 +288,16 @@ void stats::wait_finished(wait_op_type wait_op)
         p_waits += (acc_waits--) ? diff : 0.0;
 
         if (wait_op == WAIT_OP_READ) {
-            double diff = now - p_begin_wait_read;
-            t_wait_read += double(acc_wait_read) * diff;
+            double diff2 = now - p_begin_wait_read;
+            t_wait_read += double(acc_wait_read) * diff2;
             p_begin_wait_read = now;
-            p_wait_read += (acc_wait_read--) ? diff : 0.0;
+            p_wait_read += (acc_wait_read--) ? diff2 : 0.0;
         }
         else /* if (wait_op == WAIT_OP_WRITE) */ {
-            double diff = now - p_begin_wait_write;
-            t_wait_write += double(acc_wait_write) * diff;
+            double diff2 = now - p_begin_wait_write;
+            t_wait_write += double(acc_wait_write) * diff2;
             p_begin_wait_write = now;
-            p_wait_write += (acc_wait_write--) ? diff : 0.0;
+            p_wait_write += (acc_wait_write--) ? diff2 : 0.0;
         }
 #ifdef STXXL_WAIT_LOG_ENABLED
         std::ofstream* waitlog = stxxl::logger::get_instance()->waitlog_stream();

--- a/lib/io/wfs_file_base.cpp
+++ b/lib/io/wfs_file_base.cpp
@@ -100,11 +100,11 @@ static HANDLE open_file_impl(const std::string& filename, int mode)
 
         dwFlagsAndAttributes &= ~FILE_FLAG_NO_BUFFERING;
 
-        HANDLE file_des = ::CreateFileA(filename.c_str(), dwDesiredAccess, dwShareMode, NULL,
+        HANDLE file_des2 = ::CreateFileA(filename.c_str(), dwDesiredAccess, dwShareMode, NULL,
                                         dwCreationDisposition, dwFlagsAndAttributes, NULL);
 
-        if (file_des != INVALID_HANDLE_VALUE)
-            return file_des;
+        if (file_des2 != INVALID_HANDLE_VALUE)
+            return file_des2;
     }
 #endif
 


### PR DESCRIPTION
Removes warning C4456 on MSVC2015: `"C4456: declaration of '*' hides previous local declaration"`
```
1>------ Build started: Project: stxxl (libs\stxxl\stxxl), Configuration: Release x64 ------
1>  async_schedule.cpp
1>...\stxxl\lib\algo\async_schedule.cpp(115): warning C4456: declaration of 'i' hides previous local declaration
1>  ...\stxxl\lib\algo\async_schedule.cpp(87): note: see declaration of 'i'
1>...\stxxl\lib\algo\async_schedule.cpp(160): warning C4456: declaration of 'i' hides previous local declaration
1>  ...\stxxl\lib\algo\async_schedule.cpp(87): note: see declaration of 'i'
1>  iostats.cpp
1>...\stxxl\lib\io\iostats.cpp(291): warning C4456: declaration of 'diff' hides previous local declaration
1>  ...\stxxl\lib\io\iostats.cpp(285): note: see declaration of 'diff'
1>...\stxxl\lib\io\iostats.cpp(297): warning C4456: declaration of 'diff' hides previous local declaration
1>  ...\stxxl\lib\io\iostats.cpp(285): note: see declaration of 'diff'
1>  wfs_file_base.cpp
1>...\stxxl\lib\io\wfs_file_base.cpp(103): warning C4456: declaration of 'file_des' hides previous local declaration
1>  ...\stxxl\lib\io\wfs_file_base.cpp(90): note: see declaration of 'file_des'
``` 
