### PR TITLE
Add noexcept(false) attributes. Fixes #60

### DIFF
--- a/include/stxxl/bits/common/condition_variable.h
+++ b/include/stxxl/bits/common/condition_variable.h
@@ -55,7 +55,7 @@ public:
         STXXL_CHECK_PTHREAD_CALL(pthread_cond_init(&cond, NULL));
     }
     //! destroy condition variable
-    ~condition_variable()
+    ~condition_variable() noexcept(false)
     {
         STXXL_CHECK_PTHREAD_CALL(pthread_cond_destroy(&cond));
     }

--- a/include/stxxl/bits/common/mutex.h
+++ b/include/stxxl/bits/common/mutex.h
@@ -59,7 +59,7 @@ public:
         STXXL_CHECK_PTHREAD_CALL(pthread_mutex_init(&m_mutex, NULL));
     }
     //! destroy mutex handle
-    ~mutex()
+    ~mutex() noexcept(false)
     {
         // try simple delete first
         int res = pthread_mutex_destroy(&m_mutex);

--- a/include/stxxl/bits/io/file.h
+++ b/include/stxxl/bits/io/file.h
@@ -151,7 +151,7 @@ public:
     //! close and remove file
     virtual void close_remove() { }
 
-    virtual ~file()
+    virtual ~file() noexcept(false)
     {
         unsigned_type nr = get_request_nref();
         if (nr != 0)

--- a/include/stxxl/bits/io/request.h
+++ b/include/stxxl/bits/io/request.h
@@ -58,7 +58,7 @@ public:
             size_type bytes,
             request_type type);
 
-    virtual ~request();
+    virtual ~request() noexcept(false);
 
     file * get_file() const { return m_file; }
     void * get_buffer() const { return m_buffer; }

--- a/include/stxxl/bits/io/request_interface.h
+++ b/include/stxxl/bits/io/request_interface.h
@@ -74,7 +74,7 @@ public:
     //! Dumps properties of a request.
     virtual std::ostream & print(std::ostream& out) const = 0;
 
-    virtual ~request_interface()
+    virtual ~request_interface() noexcept(false)
     { }
 };
 

--- a/include/stxxl/bits/io/request_queue.h
+++ b/include/stxxl/bits/io/request_queue.h
@@ -31,7 +31,7 @@ public:
 public:
     virtual void add_request(request_ptr& req) = 0;
     virtual bool cancel_request(request_ptr& req) = 0;
-    virtual ~request_queue() { }
+    virtual ~request_queue() noexcept(false) { }
     virtual void set_priority_op(priority_op p) { STXXL_UNUSED(p); }
 };
 


### PR DESCRIPTION
noexcept(false) is needed here as ~condition_variable() and ~mutex() may
throw but are default noexcept und C++11 rules as pointed out by a GCC
diagnostic.