### PR TITLE
Minimal fix for msvc17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ if(MSVC)
   add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
   # disable lots of warnings about "unsecure" STL functions
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -pedantic -Wno-long-long")
   # detect -Wextra

--- a/include/stxxl/bits/parallel/multiway_mergesort.h
+++ b/include/stxxl/bits/parallel/multiway_mergesort.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <iterator>
 #include <algorithm>
+#include <memory>
 
 #include <stxxl/bits/config.h>
 #include <stxxl/bits/parallel/compiletime_settings.h>


### PR DESCRIPTION
See https://github.com/stxxl/stxxl/issues/57
This PR fixes the only two compile errors existing for MSVC 2017 (static build)