### PR TITLE
Fix msvc17 threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ if(MSVC)
   add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
   # disable lots of warnings about "unsecure" STL functions
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -pedantic -Wno-long-long")
   # detect -Wextra

--- a/include/stxxl/bits/parallel/multiway_mergesort.h
+++ b/include/stxxl/bits/parallel/multiway_mergesort.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <iterator>
 #include <algorithm>
+#include <memory>
 
 #include <stxxl/bits/config.h>
 #include <stxxl/bits/parallel/compiletime_settings.h>

--- a/lib/io/linuxaio_queue.cpp
+++ b/lib/io/linuxaio_queue.cpp
@@ -262,7 +262,7 @@ void* linuxaio_queue::post_async(void* arg)
     self_type* pthis = static_cast<self_type*>(arg);
     pthis->post_thread_state.set_to(TERMINATED);
 
-#if STXXL_STD_THREADS && STXXL_MSVC >= 1700
+#if STXXL_STD_THREADS && STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
     // Workaround for deadlock bug in Visual C++ Runtime 2012 and 2013, see
     // request_queue_impl_worker.cpp. -tb
     ExitThread(NULL);
@@ -278,7 +278,7 @@ void* linuxaio_queue::wait_async(void* arg)
     self_type* pthis = static_cast<self_type*>(arg);
     pthis->wait_thread_state.set_to(TERMINATED);
 
-#if STXXL_STD_THREADS && STXXL_MSVC >= 1700
+#if STXXL_STD_THREADS && STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
     // Workaround for deadlock bug in Visual C++ Runtime 2012 and 2013, see
     // request_queue_impl_worker.cpp. -tb
     ExitThread(NULL);

--- a/lib/io/request_queue_impl_1q.cpp
+++ b/lib/io/request_queue_impl_1q.cpp
@@ -21,7 +21,7 @@
 #include <stxxl/bits/io/serving_request.h>
 #include <stxxl/bits/parallel.h>
 
-#if STXXL_STD_THREADS && STXXL_MSVC >= 1700
+#if STXXL_STD_THREADS && STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
  #include <windows.h>
 #endif
 
@@ -147,7 +147,7 @@ void* request_queue_impl_1q::worker(void* arg)
 
     pthis->m_thread_state.set_to(TERMINATED);
 
-#if STXXL_STD_THREADS && STXXL_MSVC >= 1700
+#if STXXL_STD_THREADS && STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
     // Workaround for deadlock bug in Visual C++ Runtime 2012 and 2013, see
     // request_queue_impl_worker.cpp. -tb
     ExitThread(NULL);

--- a/lib/io/request_queue_impl_qwqr.cpp
+++ b/lib/io/request_queue_impl_qwqr.cpp
@@ -20,7 +20,7 @@
 #include <stxxl/bits/io/serving_request.h>
 #include <stxxl/bits/parallel.h>
 
-#if STXXL_STD_THREADS && STXXL_MSVC >= 1700
+#if STXXL_STD_THREADS && STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
  #include <windows.h>
 #endif
 
@@ -215,7 +215,7 @@ void* request_queue_impl_qwqr::worker(void* arg)
 
     pthis->m_thread_state.set_to(TERMINATED);
 
-#if STXXL_STD_THREADS && STXXL_MSVC >= 1700
+#if STXXL_STD_THREADS && STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
     // Workaround for deadlock bug in Visual C++ Runtime 2012 and 2013, see
     // request_queue_impl_worker.cpp. -tb
     ExitThread(NULL);

--- a/lib/io/request_queue_impl_worker.cpp
+++ b/lib/io/request_queue_impl_worker.cpp
@@ -26,7 +26,7 @@
 #if STXXL_BOOST_THREADS
  #include <boost/bind.hpp>
 #endif
-#if STXXL_STD_THREADS && STXXL_MSVC >= 1700
+#if STXXL_STD_THREADS && STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
  #include <windows.h>
 #endif
 
@@ -51,7 +51,7 @@ void request_queue_impl_worker::stop_thread(thread_type& t, state<thread_state>&
     s.set_to(TERMINATING);
     sem++;
 #if STXXL_STD_THREADS
-#if STXXL_MSVC >= 1700
+#if STXXL_MSVC >= 1700 && STXXL_MSVC <= 1800
     // In the Visual C++ Runtime 2012 and 2013, there is a deadlock bug, which
     // occurs when threads are joined after main() exits. Apparently, Microsoft
     // thinks this is not a big issue. It has not been fixed in VC++RT 2013.


### PR DESCRIPTION
There is a workaround in the code that is needed for Visual Studio 2012/2013. On Visual Stuidio 2017 it gives the runtime error when joining threads, so it is better to remove it (adding more #if parts).

Is this a orrect branch to post PR or WIndows-compatible version is developed elsewhere currently?
