### PR TITLE
Fixed compatibility with Clang and C++17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: cpp
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: precise
 language: cpp
 
 env:

--- a/include/stxxl/bits/compat/unique_ptr.h
+++ b/include/stxxl/bits/compat/unique_ptr.h
@@ -22,7 +22,7 @@ STXXL_BEGIN_NAMESPACE
 
 template <class Type>
 struct compat_unique_ptr {
-#if __cplusplus >= 201103L && ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) >= 40400)
+#if __cplusplus >= 201103L
     typedef std::unique_ptr<Type> result;
 #else
     // auto_ptr is inherently broken and is deprecated by unique_ptr in c++0x

--- a/include/stxxl/bits/mng/block_alloc.h
+++ b/include/stxxl/bits/mng/block_alloc.h
@@ -137,8 +137,13 @@ private:
         for (unsigned_type i = 0; i < diff; i++)
             perm[i] = i;
 
-        stxxl::random_number<random_uniform_fast> rnd;
-        std::random_shuffle(perm.begin(), perm.end(), rnd _STXXL_FORCE_SEQUENTIAL);
+        #if __cplusplus > 201402L
+            std::shuffle(perm.begin(), perm.end(), std::mt19937(std::random_device()()) _STXXL_FORCE_SEQUENTIAL);
+        #else
+            stxxl::random_number<random_uniform_fast> rnd;
+            std::random_shuffle(perm.begin(), perm.end(), rnd _STXXL_FORCE_SEQUENTIAL);
+        #endif
+
     }
 
 public:

--- a/include/stxxl/bits/mng/block_alloc_interleaved.h
+++ b/include/stxxl/bits/mng/block_alloc_interleaved.h
@@ -92,8 +92,12 @@ struct interleaved_RC : public interleaved_striping
             for (unsigned_type j = 0; j < diff; j++)
                 perms[i][j] = j;
 
-            random_number<random_uniform_fast> rnd;
-            std::random_shuffle(perms[i].begin(), perms[i].end(), rnd _STXXL_FORCE_SEQUENTIAL);
+            #if __cplusplus > 201402L
+                std::shuffle(perms[i].begin(), perms[i].end(), std::mt19937(std::random_device()()) _STXXL_FORCE_SEQUENTIAL);
+            #else
+                random_number<random_uniform_fast> rnd;
+                std::random_shuffle(perms[i].begin(), perms[i].end(), rnd _STXXL_FORCE_SEQUENTIAL);
+            #endif
         }
     }
 

--- a/include/stxxl/bits/mng/disk_allocator.h
+++ b/include/stxxl/bits/mng/disk_allocator.h
@@ -189,7 +189,8 @@ void disk_allocator::new_blocks(BID<BlockSize>* begin, BID<BlockSize>* end)
 
     sortseq::iterator space;
     space = std::find_if(free_space.begin(), free_space.end(),
-                         bind2nd(first_fit(), requested_size) _STXXL_FORCE_SEQUENTIAL);
+                         std::bind(first_fit(), std::placeholders::_1, requested_size) _STXXL_FORCE_SEQUENTIAL);
+
 
     if (space == free_space.end() && requested_size == BlockSize)
     {
@@ -207,7 +208,7 @@ void disk_allocator::new_blocks(BID<BlockSize>* begin, BID<BlockSize>* end)
         grow_file(BlockSize);
 
         space = std::find_if(free_space.begin(), free_space.end(),
-                             bind2nd(first_fit(), requested_size) _STXXL_FORCE_SEQUENTIAL);
+                             std::bind(first_fit(), std::placeholders::_1, requested_size) _STXXL_FORCE_SEQUENTIAL);
     }
 
     if (space != free_space.end())

--- a/include/stxxl/bits/parallel.h
+++ b/include/stxxl/bits/parallel.h
@@ -116,17 +116,14 @@ namespace potentially_parallel {
 #if STXXL_WITH_GNU_PARALLEL
 
 using __gnu_parallel::sort;
-using __gnu_parallel::random_shuffle;
 
 #elif STXXL_PARALLEL
 
 using std::sort;
-using std::random_shuffle;
 
 #else
 
 using std::sort;
-using std::random_shuffle;
 
 #endif
 


### PR DESCRIPTION
C++17 deprecates `random_shuffle` and `bind2nd `.

`stxxl::random_number<random_uniform_fast> rnd;` cannot be used here since `std::shuffle` requires 
`stxxl::random_number` to have `max()` and `min()` functions, which cannot be implemented since `N` is passed to at random number generation time.

`&& ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) >= 40400)` in order to support `Clang` too
