### PR TITLE
Build fixes for C++17 (due to errors in Visual Studio)

### DIFF
--- a/include/stxxl/bits/algo/ksort.h
+++ b/include/stxxl/bits/algo/ksort.h
@@ -215,7 +215,7 @@ create_runs(
     int_type* bucket2 = new int_type[k2];
     int_type i;
 
-    disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+    disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
     for (i = 0; i < run_size; i++)
     {
@@ -601,7 +601,7 @@ ksort_blocks(InputBidIterator input_bids, unsigned_type _n,
 
     double io_wait_after_rf = stats::get_instance()->get_io_wait_time();
 
-    disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+    disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
     const int_type merge_factor = optimal_merge_factor(nruns, _m);
     run_type** new_runs;

--- a/include/stxxl/bits/algo/sort.h
+++ b/include/stxxl/bits/algo/sort.h
@@ -92,7 +92,7 @@ create_runs(
     read_next_after_write_completed<block_type, bid_type>* next_run_reads =
         new read_next_after_write_completed<block_type, bid_type>[m2];
 
-    disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+    disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
     int_type i;
     int_type run_size = 0;
@@ -558,7 +558,7 @@ sort_blocks(InputBidIterator input_bids,
 
     double io_wait_after_rf = stats::get_instance()->get_io_wait_time();
 
-    disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+    disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
     const int_type merge_factor = optimal_merge_factor(nruns, _m);
     run_type** new_runs;

--- a/include/stxxl/bits/algo/stable_ksort.h
+++ b/include/stxxl/bits/algo/stable_ksort.h
@@ -267,7 +267,7 @@ void stable_ksort(ExtIterator first, ExtIterator last, unsigned_type M)
 
     int64* bucket_sizes = new int64[nbuckets];
 
-    disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+    disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
     stable_ksort_local::distribute(
         bucket_bids,
@@ -314,7 +314,7 @@ void stable_ksort(ExtIterator first, ExtIterator last, unsigned_type M)
         typedef buf_ostream<block_type, bids_container_iterator> buf_ostream_type;
         buf_ostream_type out(first.bid(), nwrite_buffers_bs);
 
-        disk_queues::get_instance()->set_priority_op(request_queue::READ);
+        disk_queues::get_instance()->set_priority_op(request_queue::priority_op::READ);
 
         if (first.block_offset())
         {

--- a/include/stxxl/bits/common/timer.h
+++ b/include/stxxl/bits/common/timer.h
@@ -53,7 +53,7 @@ timestamp()
                  double(Duration.fractional_seconds()) / (pow(10., Duration.num_fractional_digits()));
     return sec;
 #elif STXXL_WINDOWS
-    return GetTickCount() / 1000.0;
+    return GetTickCount64() / 1000.0;
 #else
     struct timeval tp;
     gettimeofday(&tp, NULL);

--- a/include/stxxl/bits/compat/unique_ptr.h
+++ b/include/stxxl/bits/compat/unique_ptr.h
@@ -22,12 +22,7 @@ STXXL_BEGIN_NAMESPACE
 
 template <class Type>
 struct compat_unique_ptr {
-#if __cplusplus >= 201103L && ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) >= 40400)
     typedef std::unique_ptr<Type> result;
-#else
-    // auto_ptr is inherently broken and is deprecated by unique_ptr in c++0x
-    typedef std::auto_ptr<Type> result;
-#endif
 };
 
 STXXL_END_NAMESPACE

--- a/include/stxxl/bits/io/iostats.h
+++ b/include/stxxl/bits/io/iostats.h
@@ -68,7 +68,7 @@ class stats : public singleton<stats>
     stats();
 
 public:
-    enum wait_op_type {
+    enum class wait_op_type {
         WAIT_OP_ANY,
         WAIT_OP_READ,
         WAIT_OP_WRITE

--- a/include/stxxl/bits/io/linuxaio_queue.h
+++ b/include/stxxl/bits/io/linuxaio_queue.h
@@ -67,7 +67,7 @@ private:
     //    and the OS to produce I/O completion events at the same time
     //    (IOCB_CMD_NOOP does not seem to help here either)
 
-    static const priority_op _priority_op = WRITE;
+    static const priority_op _priority_op = priority_op::WRITE;
 
     static void * post_async(void* arg);   // thread start callback
     static void * wait_async(void* arg);   // thread start callback

--- a/include/stxxl/bits/io/linuxaio_request.h
+++ b/include/stxxl/bits/io/linuxaio_request.h
@@ -54,7 +54,7 @@ public:
                                " linuxaio_request" <<
                                "(file=" << file << " buffer=" << buffer <<
                                " offset=" << offset << " bytes=" << bytes <<
-                               " type=" << type << ")");
+                               " type=" << ((type == request::request_type::READ) ? "READ" : "WRITE") << ")");
     }
 
     bool post();

--- a/include/stxxl/bits/io/request_interface.h
+++ b/include/stxxl/bits/io/request_interface.h
@@ -38,7 +38,7 @@ class request_interface : private noncopyable
 public:
     typedef stxxl::external_size_type offset_type;
     typedef stxxl::internal_size_type size_type;
-    enum request_type { READ, WRITE };
+    enum class request_type { READ, WRITE };
 
 public:
     virtual bool add_waiter(onoff_switch* sw) = 0;

--- a/include/stxxl/bits/io/request_operations.h
+++ b/include/stxxl/bits/io/request_operations.h
@@ -103,7 +103,7 @@ inline bool poll_any(request_ptr req_array[], size_t count, size_t& index)
 template <class RequestIterator>
 RequestIterator wait_any(RequestIterator reqs_begin, RequestIterator reqs_end)
 {
-    stats::scoped_wait_timer wait_timer(stats::WAIT_OP_ANY);
+    stats::scoped_wait_timer wait_timer(stats::wait_op_type::WAIT_OP_ANY);
 
     onoff_switch sw;
 

--- a/include/stxxl/bits/io/request_queue.h
+++ b/include/stxxl/bits/io/request_queue.h
@@ -26,7 +26,7 @@ STXXL_BEGIN_NAMESPACE
 class request_queue : private noncopyable
 {
 public:
-    enum priority_op { READ, WRITE, NONE };
+    enum class priority_op { READ, WRITE, NONE };
 
 public:
     virtual void add_request(request_ptr& req) = 0;

--- a/include/stxxl/bits/io/request_queue_impl_1q.h
+++ b/include/stxxl/bits/io/request_queue_impl_1q.h
@@ -40,7 +40,7 @@ private:
     thread_type m_thread;
     semaphore m_sem;
 
-    static const priority_op m_priority_op = WRITE;
+    static const priority_op m_priority_op = priority_op::WRITE;
 
     static void * worker(void* arg);
 

--- a/include/stxxl/bits/io/request_queue_impl_qwqr.h
+++ b/include/stxxl/bits/io/request_queue_impl_qwqr.h
@@ -44,7 +44,7 @@ private:
     thread_type m_thread;
     semaphore m_sem;
 
-    static const priority_op m_priority_op = WRITE;
+    static const priority_op m_priority_op = priority_op::WRITE;
 
     static void * worker(void* arg);
 

--- a/include/stxxl/bits/io/request_queue_impl_worker.h
+++ b/include/stxxl/bits/io/request_queue_impl_worker.h
@@ -43,7 +43,7 @@ STXXL_BEGIN_NAMESPACE
 class request_queue_impl_worker : public request_queue
 {
 protected:
-    enum thread_state { NOT_RUNNING, RUNNING, TERMINATING, TERMINATED };
+    enum class thread_state { NOT_RUNNING, RUNNING, TERMINATING, TERMINATED };
 
 #if STXXL_STD_THREADS
     typedef std::thread* thread_type;

--- a/include/stxxl/bits/io/request_with_state.h
+++ b/include/stxxl/bits/io/request_with_state.h
@@ -30,7 +30,7 @@ class request_with_state : public request_with_waiters
 protected:
     //! states of request
     //! OP - operating, DONE - request served, READY2DIE - can be destroyed
-    enum request_state { OP = 0, DONE = 1, READY2DIE = 2 };
+    enum class request_state { OP = 0, DONE = 1, READY2DIE = 2 };
 
     state<request_state> m_state;
 
@@ -42,8 +42,7 @@ protected:
         offset_type off,
         size_type b,
         request_type t)
-        : request_with_waiters(on_cmpl, f, buf, off, b, t),
-          m_state(OP)
+        : request_with_waiters(on_cmpl, f, buf, off, b, t), m_state(request_state::OP)
     { }
 
 public:

--- a/include/stxxl/bits/io/wbtl_file.h
+++ b/include/stxxl/bits/io/wbtl_file.h
@@ -65,7 +65,7 @@ class wbtl_file : public disk_queued_file
     size_type curpos;
     request_ptr backend_request;
 
-    struct FirstFit : public std::binary_function<place, offset_type, bool>
+    struct FirstFit
     {
         bool operator () (
             const place& entry,

--- a/include/stxxl/bits/mng/block_alloc.h
+++ b/include/stxxl/bits/mng/block_alloc.h
@@ -15,6 +15,7 @@
 #define STXXL_MNG_BLOCK_ALLOC_HEADER
 
 #include <algorithm>
+#include <random>
 #include <stxxl/bits/parallel.h>
 #include <stxxl/bits/common/rand.h>
 #include <stxxl/bits/mng/config.h>

--- a/include/stxxl/bits/mng/block_alloc.h
+++ b/include/stxxl/bits/mng/block_alloc.h
@@ -138,7 +138,7 @@ private:
             perm[i] = i;
 
         stxxl::random_number<random_uniform_fast> rnd;
-        std::random_shuffle(perm.begin(), perm.end(), rnd _STXXL_FORCE_SEQUENTIAL);
+        std::shuffle(perm.begin(), perm.end(), std::mt19937(std::random_device()()));
     }
 
 public:

--- a/include/stxxl/bits/mng/block_prefetcher.h
+++ b/include/stxxl/bits/mng/block_prefetcher.h
@@ -85,7 +85,7 @@ protected:
     {
         STXXL_VERBOSE1("block_prefetcher: waiting block " << iblock);
         {
-            stats::scoped_wait_timer wait_timer(stats::WAIT_OP_READ);
+            stats::scoped_wait_timer wait_timer(stats::wait_op_type::WAIT_OP_READ);
 
             completed[iblock].wait_for_on();
         }

--- a/include/stxxl/bits/mng/buf_writer.h
+++ b/include/stxxl/bits/mng/buf_writer.h
@@ -83,7 +83,7 @@ public:
         for (unsigned_type i = 0; i < nwriteblocks; i++)
             free_write_blocks.push_back(i);
 
-        disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+        disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
     }
     //! Returns free block from the internal buffer pool.
     //! \return pointer to the block from the internal buffer pool

--- a/include/stxxl/bits/mng/config.h
+++ b/include/stxxl/bits/mng/config.h
@@ -169,7 +169,9 @@ public:
     //! has no effect after construction of block_manager.
     inline config & add_disk(const disk_config& cfg)
     {
-        disks_list.push_back(cfg);
+        if (not is_initialized){
+            disks_list.push_back(cfg);
+        }
         return *this;
     }
 

--- a/include/stxxl/bits/mng/disk_allocator.h
+++ b/include/stxxl/bits/mng/disk_allocator.h
@@ -44,7 +44,7 @@ class disk_allocator : private noncopyable
 {
     typedef std::pair<stxxl::int64, stxxl::int64> place;
 
-    struct first_fit : public std::binary_function<place, stxxl::int64, bool>
+    struct first_fit
     {
         bool operator () (
             const place& entry,
@@ -189,7 +189,7 @@ void disk_allocator::new_blocks(BID<BlockSize>* begin, BID<BlockSize>* end)
 
     sortseq::iterator space;
     space = std::find_if(free_space.begin(), free_space.end(),
-                         bind2nd(first_fit(), requested_size) _STXXL_FORCE_SEQUENTIAL);
+                         std::bind(first_fit(), std::placeholders::_1, requested_size) _STXXL_FORCE_SEQUENTIAL);
 
     if (space == free_space.end() && requested_size == BlockSize)
     {
@@ -207,7 +207,7 @@ void disk_allocator::new_blocks(BID<BlockSize>* begin, BID<BlockSize>* end)
         grow_file(BlockSize);
 
         space = std::find_if(free_space.begin(), free_space.end(),
-                             bind2nd(first_fit(), requested_size) _STXXL_FORCE_SEQUENTIAL);
+                             std::bind(first_fit(), std::placeholders::_1, requested_size) _STXXL_FORCE_SEQUENTIAL);
     }
 
     if (space != free_space.end())

--- a/include/stxxl/bits/mng/prefetch_pool.h
+++ b/include/stxxl/bits/mng/prefetch_pool.h
@@ -234,7 +234,7 @@ public:
 
         // cancel request if it is a read request, there might be
         // write requests 'stolen' from a write_pool that may not be canceled
-        if (cache_el->second.second->get_type() == request::READ)
+        if (cache_el->second.second->get_type() == request::request_type::READ)
             cache_el->second.second->cancel();
         // finish the request
         cache_el->second.second->wait();

--- a/include/stxxl/bits/msvc_compatibility.h
+++ b/include/stxxl/bits/msvc_compatibility.h
@@ -19,11 +19,6 @@
 
 #include <cmath>
 
-inline double log2(double x)
-{
-    return (log(x) / log(2.));
-}
-
 // http://msdn.microsoft.com/en-us/library/2ts7cx93.aspx
 #define snprintf _snprintf
 

--- a/include/stxxl/bits/parallel.h
+++ b/include/stxxl/bits/parallel.h
@@ -121,12 +121,10 @@ using __gnu_parallel::random_shuffle;
 #elif STXXL_PARALLEL
 
 using std::sort;
-using std::random_shuffle;
 
 #else
 
 using std::sort;
-using std::random_shuffle;
 
 #endif
 

--- a/include/stxxl/bits/parallel/base.h
+++ b/include/stxxl/bits/parallel/base.h
@@ -33,7 +33,6 @@ namespace parallel {
  */
 template <class Predicate, typename first_argument_type, typename second_argument_type>
 class binary_negate
-    : public std::binary_function<first_argument_type, second_argument_type, bool>
 {
 protected:
     Predicate pred;
@@ -80,7 +79,7 @@ static inline void decode2(lcas_t x, int& a, int& b)
  * Constructs predicate for equality from strict weak ordering predicate
  */
 template <class Comparator, typename T1, typename T2>
-class equal_from_less : public std::binary_function<T1, T2, bool>
+class equal_from_less
 {
 private:
     Comparator& comp;
@@ -126,7 +125,7 @@ median_of_three_iterators(RandomAccessIterator a, RandomAccessIterator b,
 
 /** Similar to std::equal_to, but allows two different types. */
 template <typename T1, typename T2>
-struct equal_to : std::binary_function<T1, T2, bool>
+struct equal_to
 {
     bool operator () (const T1& t1, const T2& t2) const
     {
@@ -136,7 +135,7 @@ struct equal_to : std::binary_function<T1, T2, bool>
 
 /** Similar to std::less, but allows two different types. */
 template <typename T1, typename T2>
-struct less : std::binary_function<T1, T2, bool>
+struct less
 {
     bool operator () (const T1& t1, const T2& t2) const
     {

--- a/include/stxxl/bits/parallel/multiseq_selection.h
+++ b/include/stxxl/bits/parallel/multiseq_selection.h
@@ -35,7 +35,6 @@ namespace parallel {
 //! Compare a pair of types lexcigraphically, ascending.
 template <typename T1, typename T2, typename Comparator>
 class lexicographic
-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool>
 {
 protected:
     Comparator& m_comp;
@@ -60,7 +59,6 @@ public:
 //! Compare a pair of types lexcigraphically, descending.
 template <typename T1, typename T2, typename Comparator>
 class lexicographic_rev
-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool>
 {
 protected:
     Comparator& m_comp;

--- a/include/stxxl/bits/stream/sort_stream.h
+++ b/include/stxxl/bits/stream/sort_stream.h
@@ -228,7 +228,7 @@ void basic_runs_creator<Input, CompareType, BlockSize, AllocStr>::compute_result
     run.resize(cur_run_size);
     bm->new_blocks(AllocStr(), make_bid_iterator(run.begin()), make_bid_iterator(run.end()));
 
-    disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+    disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
     // fill the rest of the last block with max values
     fill_with_max_value(Blocks1, cur_run_size, blocks1_length);
@@ -515,7 +515,7 @@ protected:
         block_manager* bm = block_manager::get_instance();
         bm->new_blocks(AllocStr(), make_bid_iterator(run.begin()), make_bid_iterator(run.end()));
 
-        disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+        disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
         // fill the rest of the last block with max values
         fill_with_max_value(m_blocks1, cur_run_size, m_cur_el);
@@ -638,7 +638,7 @@ public:
         block_manager* bm = block_manager::get_instance();
         bm->new_blocks(AllocStr(), make_bid_iterator(run.begin()), make_bid_iterator(run.end()));
 
-        disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+        disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
         for (unsigned_type i = 0; i < cur_run_blocks; ++i)
         {
@@ -1150,7 +1150,7 @@ public:
 
         // *** test whether recursive merging is necessary
 
-        disk_queues::get_instance()->set_priority_op(request_queue::WRITE);
+        disk_queues::get_instance()->set_priority_op(request_queue::priority_op::WRITE);
 
         int_type disks_number = config::get_instance()->disks_number();
         unsigned_type min_prefetch_buffers = 2 * disks_number;

--- a/lib/algo/async_schedule.cpp
+++ b/lib/algo/async_schedule.cpp
@@ -44,7 +44,7 @@ struct sim_event
     inline sim_event(int_type t, int_type b) : timestamp(t), iblock(b) { }
 };
 
-struct sim_event_cmp : public std::binary_function<sim_event, sim_event, bool>
+struct sim_event_cmp
 {
     inline bool operator () (const sim_event& a, const sim_event& b) const
     {
@@ -53,7 +53,7 @@ struct sim_event_cmp : public std::binary_function<sim_event, sim_event, bool>
 };
 
 typedef std::pair<int_type, int_type> write_time_pair;
-struct write_time_cmp : public std::binary_function<write_time_pair, write_time_pair, bool>
+struct write_time_cmp
 {
     inline bool operator () (const write_time_pair& a, const write_time_pair& b) const
     {

--- a/lib/io/boostfd_file.cpp
+++ b/lib/io/boostfd_file.cpp
@@ -44,13 +44,13 @@ void boostfd_file::serve(void* buffer, offset_type offset, size_type bytes,
             " this=" << this <<
             " buffer=" << buffer <<
             " bytes=" << bytes <<
-            " type=" << ((type == request::READ) ? "READ" : "WRITE") <<
+            " type=" << ((type == request::request_type::READ) ? "READ" : "WRITE") <<
             " : " << ex.what());
     }
 
-    stats::scoped_read_write_timer read_write_timer(bytes, type == request::WRITE);
+    stats::scoped_read_write_timer read_write_timer(bytes, type == request::request_type::WRITE);
 
-    if (type == request::READ)
+    if (type == request::request_type::READ)
     {
         try
         {
@@ -68,7 +68,7 @@ void boostfd_file::serve(void* buffer, offset_type offset, size_type bytes,
                 " this=" << this <<
                 " buffer=" << buffer <<
                 " bytes=" << bytes <<
-                " type=" << ((type == request::READ) ? "READ" : "WRITE") <<
+                " type=" << ((type == request::request_type::READ) ? "READ" : "WRITE") <<
                 " : " << ex.what());
         }
     }
@@ -90,7 +90,7 @@ void boostfd_file::serve(void* buffer, offset_type offset, size_type bytes,
                 " this=" << this <<
                 " buffer=" << buffer <<
                 " bytes=" << bytes <<
-                " type=" << ((type == request::READ) ? "READ" : "WRITE") <<
+                " type=" << ((type == request::request_type::READ) ? "READ" : "WRITE") <<
                 " : " << ex.what());
         }
     }

--- a/lib/io/disk_queued_file.cpp
+++ b/lib/io/disk_queued_file.cpp
@@ -27,8 +27,7 @@ request_ptr disk_queued_file::aread(
     size_type bytes,
     const completion_handler& on_cmpl)
 {
-    request_ptr req(new serving_request(on_cmpl, this, buffer, pos, bytes,
-                                        request::READ));
+    request_ptr req(new serving_request(on_cmpl, this, buffer, pos, bytes, request::request_type::READ));
 
     disk_queues::get_instance()->add_request(req, get_queue_id());
 
@@ -41,8 +40,7 @@ request_ptr disk_queued_file::awrite(
     size_type bytes,
     const completion_handler& on_cmpl)
 {
-    request_ptr req(new serving_request(on_cmpl, this, buffer, pos, bytes,
-                                        request::WRITE));
+    request_ptr req(new serving_request(on_cmpl, this, buffer, pos, bytes, request::request_type::WRITE));
 
     disk_queues::get_instance()->add_request(req, get_queue_id());
 

--- a/lib/io/iostats.cpp
+++ b/lib/io/iostats.cpp
@@ -303,8 +303,8 @@ void stats::wait_finished(wait_op_type wait_op)
         std::ofstream* waitlog = stxxl::logger::get_instance()->waitlog_stream();
         if (waitlog)
             *waitlog << (now - last_reset) << "\t"
-                     << ((wait_op == WAIT_OP_READ) ? diff : 0.0) << "\t"
-                     << ((wait_op != WAIT_OP_READ) ? diff : 0.0) << "\t"
+                     << ((wait_op == wait_op_type::WAIT_OP_READ) ? diff : 0.0) << "\t"
+                     << ((wait_op != wait_op_type::WAIT_OP_READ) ? diff : 0.0) << "\t"
                      << t_wait_read << "\t" << t_wait_write << std::endl << std::flush;
 #endif
     }

--- a/lib/io/iostats.cpp
+++ b/lib/io/iostats.cpp
@@ -260,7 +260,7 @@ void stats::wait_started(wait_op_type wait_op)
         p_begin_wait = now;
         p_waits += (acc_waits++) ? diff : 0.0;
 
-        if (wait_op == WAIT_OP_READ) {
+        if (wait_op == wait_op_type::WAIT_OP_READ) {
             diff = now - p_begin_wait_read;
             t_wait_read += double(acc_wait_read) * diff;
             p_begin_wait_read = now;
@@ -287,7 +287,7 @@ void stats::wait_finished(wait_op_type wait_op)
         p_begin_wait = now;
         p_waits += (acc_waits--) ? diff : 0.0;
 
-        if (wait_op == WAIT_OP_READ) {
+        if (wait_op == wait_op_type::WAIT_OP_READ) {
             double diff2 = now - p_begin_wait_read;
             t_wait_read += double(acc_wait_read) * diff2;
             p_begin_wait_read = now;

--- a/lib/io/linuxaio_file.cpp
+++ b/lib/io/linuxaio_file.cpp
@@ -25,7 +25,7 @@ request_ptr linuxaio_file::aread(
     size_type bytes,
     const completion_handler& on_cmpl)
 {
-    request_ptr req(new linuxaio_request(on_cmpl, this, buffer, pos, bytes, request::READ));
+    request_ptr req(new linuxaio_request(on_cmpl, this, buffer, pos, bytes, request::request_type::READ));
 
     disk_queues::get_instance()->add_request(req, get_queue_id());
 
@@ -38,7 +38,7 @@ request_ptr linuxaio_file::awrite(
     size_type bytes,
     const completion_handler& on_cmpl)
 {
-    request_ptr req(new linuxaio_request(on_cmpl, this, buffer, pos, bytes, request::WRITE));
+    request_ptr req(new linuxaio_request(on_cmpl, this, buffer, pos, bytes, request::request_type::WRITE));
 
     disk_queues::get_instance()->add_request(req, get_queue_id());
 
@@ -49,7 +49,7 @@ void linuxaio_file::serve(void* buffer, offset_type offset, size_type bytes,
                           request::request_type type)
 {
     // req need not be an linuxaio_request
-    if (type == request::READ)
+    if (type == request::request_type::READ)
         aread(buffer, offset, bytes)->wait();
     else
         awrite(buffer, offset, bytes)->wait();

--- a/lib/io/linuxaio_request.cpp
+++ b/lib/io/linuxaio_request.cpp
@@ -31,14 +31,14 @@ void linuxaio_request::completed(bool posted, bool canceled)
 
     if (!canceled)
     {
-        if (m_type == READ)
+        if (m_type == request_type::READ)
             stats::get_instance()->read_finished();
         else
             stats::get_instance()->write_finished();
     }
     else if (posted)
     {
-        if (m_type == READ)
+        if (m_type == request_type::READ)
             stats::get_instance()->read_canceled(m_bytes);
         else
             stats::get_instance()->write_canceled(m_bytes);
@@ -54,7 +54,7 @@ void linuxaio_request::fill_control_block()
     // indirection, so the I/O system retains a counting_ptr reference
     cb.aio_data = reinterpret_cast<__u64>(new request_ptr(this));
     cb.aio_fildes = af->file_des;
-    cb.aio_lio_opcode = (m_type == READ) ? IOCB_CMD_PREAD : IOCB_CMD_PWRITE;
+    cb.aio_lio_opcode = (m_type == request_type::READ) ? IOCB_CMD_PREAD : IOCB_CMD_PWRITE;
     cb.aio_reqprio = 0;
     cb.aio_buf = static_cast<__u64>((unsigned long)(m_buffer));
     cb.aio_nbytes = m_bytes;
@@ -78,7 +78,7 @@ bool linuxaio_request::post()
     long success = syscall(SYS_io_submit, queue->get_io_context(), 1, &cb_pointer);
     if (success == 1)
     {
-        if (m_type == READ)
+        if (m_type == request_type::READ)
             stats::get_instance()->read_started(m_bytes, now);
         else
             stats::get_instance()->write_started(m_bytes, now);

--- a/lib/io/mem_file.cpp
+++ b/lib/io/mem_file.cpp
@@ -25,7 +25,7 @@ void mem_file::serve(void* buffer, offset_type offset, size_type bytes,
 {
     scoped_mutex_lock lock(m_mutex);
 
-    if (type == request::READ)
+    if (type == request::request_type::READ)
     {
         stats::scoped_read_timer read_timer(bytes);
         memcpy(buffer, m_ptr + offset, bytes);

--- a/lib/io/mmap_file.cpp
+++ b/lib/io/mmap_file.cpp
@@ -29,9 +29,9 @@ void mmap_file::serve(void* buffer, offset_type offset, size_type bytes,
 
     //assert(offset + bytes <= _size());
 
-    stats::scoped_read_write_timer read_write_timer(bytes, type == request::WRITE);
+    stats::scoped_read_write_timer read_write_timer(bytes, type == request::request_type::WRITE);
 
-    int prot = (type == request::READ) ? PROT_READ : PROT_WRITE;
+    int prot = (type == request::request_type::READ) ? PROT_READ : PROT_WRITE;
     void* mem = mmap(NULL, bytes, prot, MAP_SHARED, file_des, offset);
     // void *mem = mmap (buffer, bytes, prot , MAP_SHARED|MAP_FIXED , file_des, offset);
     // STXXL_MSG("Mmaped to "<<mem<<" , buffer suggested at "<<buffer);
@@ -50,7 +50,7 @@ void mmap_file::serve(void* buffer, offset_type offset, size_type bytes,
     }
     else
     {
-        if (type == request::READ)
+        if (type == request::request_type::READ)
         {
             memcpy(buffer, mem, bytes);
         }

--- a/lib/io/request.cpp
+++ b/lib/io/request.cpp
@@ -65,8 +65,7 @@ void request::check_nref_failed(bool after)
                  " this=" << this <<
                  " offset=" << m_offset <<
                  " buffer=" << m_buffer <<
-                 " bytes=" << m_bytes <<
-                 " type=" << ((m_type == READ) ? "READ" : "WRITE") <<
+                 " bytes=" << m_bytes << " type=" << ((m_type == request_type::READ) ? "READ" : "WRITE") <<
                  " file=" << m_file <<
                  " iotype=" << m_file->io_type()
                  );
@@ -83,7 +82,7 @@ std::ostream& request::print(std::ostream& out) const
     out << " Buffer address: " << static_cast<void*>(m_buffer);
     out << " File offset: " << m_offset;
     out << " Transfer size: " << m_bytes << " bytes";
-    out << " Type of transfer: " << ((m_type == READ) ? "READ" : "WRITE");
+    out << " Type of transfer: " << ((m_type == request_type::READ) ? "READ" : "WRITE");
     return out;
 }
 

--- a/lib/io/request_queue_impl_1q.cpp
+++ b/lib/io/request_queue_impl_1q.cpp
@@ -43,8 +43,7 @@ struct file_offset_match
     }
 };
 
-request_queue_impl_1q::request_queue_impl_1q(int n)
-    : m_thread_state(NOT_RUNNING), m_sem(0)
+request_queue_impl_1q::request_queue_impl_1q(int n) : m_thread_state(thread_state::NOT_RUNNING), m_sem(0)
 {
     STXXL_UNUSED(n);
     start_thread(worker, static_cast<void*>(this), m_thread, m_thread_state);
@@ -54,7 +53,7 @@ void request_queue_impl_1q::add_request(request_ptr& req)
 {
     if (req.empty())
         STXXL_THROW_INVALID_ARGUMENT("Empty request submitted to disk_queue.");
-    if (m_thread_state() != RUNNING)
+    if (m_thread_state() != thread_state::RUNNING)
         STXXL_THROW_INVALID_ARGUMENT("Request submitted to not running queue.");
     if (!dynamic_cast<serving_request*>(req.get()))
         STXXL_ERRMSG("Incompatible request submitted to running queue.");
@@ -80,7 +79,7 @@ bool request_queue_impl_1q::cancel_request(request_ptr& req)
 {
     if (req.empty())
         STXXL_THROW_INVALID_ARGUMENT("Empty request canceled disk_queue.");
-    if (m_thread_state() != RUNNING)
+    if (m_thread_state() != thread_state::RUNNING)
         STXXL_THROW_INVALID_ARGUMENT("Request canceled to not running queue.");
     if (!dynamic_cast<serving_request*>(req.get()))
         STXXL_ERRMSG("Incompatible request submitted to running queue.");
@@ -137,7 +136,7 @@ void* request_queue_impl_1q::worker(void* arg)
         }
 
         // terminate if it has been requested and queues are empty
-        if (pthis->m_thread_state() == TERMINATING) {
+        if (pthis->m_thread_state() == thread_state::TERMINATING) {
             if ((pthis->m_sem--) == 0)
                 break;
             else
@@ -145,7 +144,7 @@ void* request_queue_impl_1q::worker(void* arg)
         }
     }
 
-    pthis->m_thread_state.set_to(TERMINATED);
+    pthis->m_thread_state.set_to(thread_state::TERMINATED);
 
 #if STXXL_STD_THREADS && STXXL_MSVC >= 1700
     // Workaround for deadlock bug in Visual C++ Runtime 2012 and 2013, see

--- a/lib/io/request_queue_impl_1q.cpp
+++ b/lib/io/request_queue_impl_1q.cpp
@@ -31,7 +31,7 @@
 
 STXXL_BEGIN_NAMESPACE
 
-struct file_offset_match : public std::binary_function<request_ptr, request_ptr, bool>
+struct file_offset_match
 {
     bool operator () (
         const request_ptr& a,
@@ -63,7 +63,7 @@ void request_queue_impl_1q::add_request(request_ptr& req)
     {
         scoped_mutex_lock Lock(m_queue_mutex);
         if (std::find_if(m_queue.begin(), m_queue.end(),
-                         bind2nd(file_offset_match(), req) _STXXL_FORCE_SEQUENTIAL)
+                         std::bind(file_offset_match(), std::placeholders::_1, req) _STXXL_FORCE_SEQUENTIAL)
             != m_queue.end())
         {
             STXXL_ERRMSG("request submitted for a BID with a pending request");

--- a/lib/io/request_queue_impl_qwqr.cpp
+++ b/lib/io/request_queue_impl_qwqr.cpp
@@ -30,7 +30,7 @@
 
 STXXL_BEGIN_NAMESPACE
 
-struct file_offset_match : public std::binary_function<request_ptr, request_ptr, bool>
+struct file_offset_match
 {
     bool operator () (
         const request_ptr& a,
@@ -64,7 +64,8 @@ void request_queue_impl_qwqr::add_request(request_ptr& req)
         {
             scoped_mutex_lock Lock(m_write_mutex);
             if (std::find_if(m_write_queue.begin(), m_write_queue.end(),
-                             bind2nd(file_offset_match(), req) _STXXL_FORCE_SEQUENTIAL)
+                             std::bind(file_offset_match(), std::placeholders::_1, req)
+                                 _STXXL_FORCE_SEQUENTIAL)
                 != m_write_queue.end())
             {
                 STXXL_ERRMSG("READ request submitted for a BID with a pending WRITE request");
@@ -80,7 +81,8 @@ void request_queue_impl_qwqr::add_request(request_ptr& req)
         {
             scoped_mutex_lock Lock(m_read_mutex);
             if (std::find_if(m_read_queue.begin(), m_read_queue.end(),
-                             bind2nd(file_offset_match(), req) _STXXL_FORCE_SEQUENTIAL)
+                             std::bind(file_offset_match(), std::placeholders::_1, req)
+                                 _STXXL_FORCE_SEQUENTIAL)
                 != m_read_queue.end())
             {
                 STXXL_ERRMSG("WRITE request submitted for a BID with a pending READ request");

--- a/lib/io/request_queue_impl_worker.cpp
+++ b/lib/io/request_queue_impl_worker.cpp
@@ -42,13 +42,13 @@ void request_queue_impl_worker::start_thread(void* (*worker)(void*), void* arg, 
 #else
     STXXL_CHECK_PTHREAD_CALL(pthread_create(&t, NULL, worker, arg));
 #endif
-    s.set_to(RUNNING);
+    s.set_to(thread_state::RUNNING);
 }
 
 void request_queue_impl_worker::stop_thread(thread_type& t, state<thread_state>& s, semaphore& sem)
 {
     assert(s() == RUNNING);
-    s.set_to(TERMINATING);
+    s.set_to(thread_state::TERMINATING);
     sem++;
 #if STXXL_STD_THREADS
 #if STXXL_MSVC >= 1700
@@ -77,7 +77,7 @@ void request_queue_impl_worker::stop_thread(thread_type& t, state<thread_state>&
     STXXL_CHECK_PTHREAD_CALL(pthread_join(t, NULL));
 #endif
     assert(s() == TERMINATED);
-    s.set_to(NOT_RUNNING);
+    s.set_to(thread_state::NOT_RUNNING);
 }
 
 STXXL_END_NAMESPACE

--- a/lib/io/request_queue_impl_worker.cpp
+++ b/lib/io/request_queue_impl_worker.cpp
@@ -34,7 +34,7 @@ STXXL_BEGIN_NAMESPACE
 
 void request_queue_impl_worker::start_thread(void* (*worker)(void*), void* arg, thread_type& t, state<thread_state>& s)
 {
-    assert(s() == NOT_RUNNING);
+    assert(s() == thread_state::NOT_RUNNING);
 #if STXXL_STD_THREADS
     t = new std::thread(worker, arg);
 #elif STXXL_BOOST_THREADS
@@ -47,7 +47,7 @@ void request_queue_impl_worker::start_thread(void* (*worker)(void*), void* arg, 
 
 void request_queue_impl_worker::stop_thread(thread_type& t, state<thread_state>& s, semaphore& sem)
 {
-    assert(s() == RUNNING);
+    assert(s() == thread_state::RUNNING);
     s.set_to(thread_state::TERMINATING);
     sem++;
 #if STXXL_STD_THREADS
@@ -76,7 +76,7 @@ void request_queue_impl_worker::stop_thread(thread_type& t, state<thread_state>&
 #else
     STXXL_CHECK_PTHREAD_CALL(pthread_join(t, NULL));
 #endif
-    assert(s() == TERMINATED);
+    assert(s() == thread_state::TERMINATED);
     s.set_to(thread_state::NOT_RUNNING);
 }
 

--- a/lib/io/request_with_state.cpp
+++ b/lib/io/request_with_state.cpp
@@ -29,7 +29,7 @@ request_with_state::~request_with_state()
 {
     STXXL_VERBOSE3_THIS("request_with_state::~(), ref_cnt: " << get_reference_count());
 
-    assert(m_state() == DONE || m_state() == READY2DIE);
+    assert(m_state() == request_state::DONE || m_state() == request_state::READY2DIE);
 
     // if(m_state() != DONE && m_state()!= READY2DIE )
     // STXXL_ERRMSG("WARNING: serious stxxl inconsistency: Request is being deleted while I/O not finished. "<<

--- a/lib/io/request_with_state.cpp
+++ b/lib/io/request_with_state.cpp
@@ -42,9 +42,11 @@ void request_with_state::wait(bool measure_time)
 {
     STXXL_VERBOSE3_THIS("request_with_state::wait()");
 
-    stats::scoped_wait_timer wait_timer(m_type == READ ? stats::WAIT_OP_READ : stats::WAIT_OP_WRITE, measure_time);
+    stats::scoped_wait_timer wait_timer(
+        m_type == request_type::READ ? stats::wait_op_type::WAIT_OP_READ : stats::wait_op_type::WAIT_OP_WRITE,
+                                        measure_time);
 
-    m_state.wait_for(READY2DIE);
+    m_state.wait_for(request_state::READY2DIE);
 
     check_errors();
 }
@@ -58,11 +60,11 @@ bool request_with_state::cancel()
         request_ptr rp(this);
         if (disk_queues::get_instance()->cancel_request(rp, m_file->get_queue_id()))
         {
-            m_state.set_to(DONE);
+            m_state.set_to(request_state::DONE);
             notify_waiters();
             m_file->delete_request_ref();
             m_file = 0;
-            m_state.set_to(READY2DIE);
+            m_state.set_to(request_state::READY2DIE);
             return true;
         }
     }
@@ -75,19 +77,19 @@ bool request_with_state::poll()
 
     check_errors();
 
-    return s == DONE || s == READY2DIE;
+    return s == request_state::DONE || s == request_state::READY2DIE;
 }
 
 void request_with_state::completed(bool canceled)
 {
     STXXL_VERBOSE3_THIS("request_with_state::completed()");
-    m_state.set_to(DONE);
+    m_state.set_to(request_state::DONE);
     if (!canceled)
         m_on_complete(this);
     notify_waiters();
     m_file->delete_request_ref();
     m_file = 0;
-    m_state.set_to(READY2DIE);
+    m_state.set_to(request_state::READY2DIE);
 }
 
 STXXL_END_NAMESPACE

--- a/lib/io/request_with_waiters.cpp
+++ b/lib/io/request_with_waiters.cpp
@@ -50,7 +50,7 @@ void request_with_waiters::notify_waiters()
     scoped_mutex_lock lock(m_waiters_mutex);
     std::for_each(m_waiters.begin(),
                   m_waiters.end(),
-                  std::mem_fun(&onoff_switch::on)
+                  std::mem_fn(&onoff_switch::on)
                   _STXXL_FORCE_SEQUENTIAL);
 }
 

--- a/lib/io/serving_request.cpp
+++ b/lib/io/serving_request.cpp
@@ -49,8 +49,7 @@ void serving_request::serve()
         m_buffer << " @ [" <<
         m_file << "|" << m_file->get_allocator_id() << "]0x" <<
         std::hex << std::setfill('0') << std::setw(8) <<
-        m_offset << "/0x" << m_bytes <<
-        ((m_type == request::READ) ? " READ" : " WRITE"));
+        m_offset << "/0x" << m_bytes << ((m_type == request::request_type::READ) ? " READ" : " WRITE"));
 
     try
     {

--- a/lib/io/simdisk_file.cpp
+++ b/lib/io/simdisk_file.cpp
@@ -163,7 +163,7 @@ void sim_disk_file::serve(void* buffer, offset_type offset, size_type bytes,
 
     double op_start = timestamp();
 
-    stats::scoped_read_write_timer read_write_timer(bytes, type == request::WRITE);
+    stats::scoped_read_write_timer read_write_timer(bytes, type == request::request_type::WRITE);
 
     void* mem = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, file_des, offset);
     if (mem == MAP_FAILED)
@@ -180,7 +180,7 @@ void sim_disk_file::serve(void* buffer, offset_type offset, size_type bytes,
     }
     else
     {
-        if (type == request::READ)
+        if (type == request::request_type::READ)
         {
             memcpy(buffer, mem, bytes);
         }

--- a/lib/io/syscall_file.cpp
+++ b/lib/io/syscall_file.cpp
@@ -30,7 +30,7 @@ void syscall_file::serve(void* buffer, offset_type offset, size_type bytes,
 
     char* cbuffer = static_cast<char*>(buffer);
 
-    stats::scoped_read_write_timer read_write_timer(bytes, type == request::WRITE);
+    stats::scoped_read_write_timer read_write_timer(bytes, type == request::request_type::WRITE);
 
     while (bytes > 0)
     {
@@ -45,12 +45,13 @@ void syscall_file::serve(void* buffer, offset_type offset, size_type bytes,
                 " fd=" << file_des <<
                 " offset=" << offset <<
                 " buffer=" << cbuffer <<
-                " bytes=" << bytes <<
-                " type=" << ((type == request::READ) ? "READ" : "WRITE") <<
+                " bytes=" << bytes << " type="
+                                                 << ((type == request::request_type::READ) ? "READ" : "WRITE")
+                                                 <<
                 " rc=" << rc);
         }
 
-        if (type == request::READ)
+        if (type == request::request_type::READ)
         {
 #if STXXL_MSVC
             assert(bytes <= std::numeric_limits<unsigned int>::max());

--- a/lib/io/syscall_file.cpp
+++ b/lib/io/syscall_file.cpp
@@ -45,9 +45,8 @@ void syscall_file::serve(void* buffer, offset_type offset, size_type bytes,
                 " fd=" << file_des <<
                 " offset=" << offset <<
                 " buffer=" << cbuffer <<
-                " bytes=" << bytes << " type="
-                                                 << ((type == request::request_type::READ) ? "READ" : "WRITE")
-                                                 <<
+                " bytes=" << bytes << 
+                " type="  << ((type == request::request_type::READ) ? "READ" : "WRITE") <<
                 " rc=" << rc);
         }
 

--- a/lib/io/wbtl_file.cpp
+++ b/lib/io/wbtl_file.cpp
@@ -304,7 +304,7 @@ wbtl_file::offset_type wbtl_file::get_next_write_block()
     // mapping_lock has to be aquired by caller
     sortseq::iterator space =
         std::find_if(free_space.begin(), free_space.end(),
-                     bind2nd(FirstFit(), write_block_size) _STXXL_FORCE_SEQUENTIAL);
+                     std::bind(FirstFit(), std::placeholders::_1, write_block_size) _STXXL_FORCE_SEQUENTIAL);
 
     if (space != free_space.end())
     {

--- a/lib/io/wbtl_file.cpp
+++ b/lib/io/wbtl_file.cpp
@@ -58,7 +58,7 @@ wbtl_file::~wbtl_file()
 void wbtl_file::serve(void* buffer, offset_type offset, size_type bytes,
                       request::request_type type)
 {
-    if (type == request::READ)
+    if (type == request::request_type::READ)
     {
         //stats::scoped_read_timer read_timer(size());
         sread(buffer, offset, bytes);

--- a/lib/io/wincall_file.cpp
+++ b/lib/io/wincall_file.cpp
@@ -44,14 +44,13 @@ void wincall_file::serve(void* buffer, offset_type offset, size_type bytes,
                                   " offset=" << offset <<
                                   " this=" << this <<
                                   " buffer=" << buffer <<
-                                  " bytes=" << bytes <<
-                                  " type=" << ((type == request::READ) ? "READ" : "WRITE"));
+                                  " bytes=" << bytes << " type=" << ((type == request::request_type::READ) ? "READ" : "WRITE"));
     }
     else
     {
-        stats::scoped_read_write_timer read_write_timer(bytes, type == request::WRITE);
+        stats::scoped_read_write_timer read_write_timer(bytes, type == request::request_type::WRITE);
 
-        if (type == request::READ)
+        if (type == request::request_type::READ)
         {
             DWORD NumberOfBytesRead = 0;
             assert(bytes <= std::numeric_limits<DWORD>::max());
@@ -62,8 +61,8 @@ void wincall_file::serve(void* buffer, offset_type offset, size_type bytes,
                                           " this=" << this <<
                                           " offset=" << offset <<
                                           " buffer=" << buffer <<
-                                          " bytes=" << bytes <<
-                                          " type=" << ((type == request::READ) ? "READ" : "WRITE") <<
+                                          " bytes=" << bytes << 
+                                          " type=" << ((type == request::request_type::READ) ? "READ" : "WRITE") <<
                                           " NumberOfBytesRead= " << NumberOfBytesRead);
             }
             else if (NumberOfBytesRead != bytes) {
@@ -81,8 +80,8 @@ void wincall_file::serve(void* buffer, offset_type offset, size_type bytes,
                                           " this=" << this <<
                                           " offset=" << offset <<
                                           " buffer=" << buffer <<
-                                          " bytes=" << bytes <<
-                                          " type=" << ((type == request::READ) ? "READ" : "WRITE") <<
+                                          " bytes=" << bytes << 
+                                          " type="  << ((type == request::request_type::READ) ? "READ" : "WRITE") <<
                                           " NumberOfBytesWritten= " << NumberOfBytesWritten);
             }
             else if (NumberOfBytesWritten != bytes) {


### PR DESCRIPTION
There are several std classes/functions that are removed in C++17 and causes build errors. This PR removes and replaces them as necessary. In addition there are a few build warnings (in particular recommending enum class) that are fixed as well.

Please check that this causes no problems/changes on Linux