### PR TITLE
Guard definition of log2 on versions of Visual C++ that provide it.

### DIFF
--- a/include/stxxl/bits/msvc_compatibility.h
+++ b/include/stxxl/bits/msvc_compatibility.h
@@ -19,10 +19,12 @@
 
 #include <cmath>
 
+#if _MSC_VER < 1900
 inline double log2(double x)
 {
     return (log(x) / log(2.));
 }
+#endif // ^^^ _MSC_VER < 1900
 
 // http://msdn.microsoft.com/en-us/library/2ts7cx93.aspx
 #define snprintf _snprintf


### PR DESCRIPTION
Resolves:

```
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1432~1.313\bin\Hostx64\arm64\cl.exe   /TP -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -D_SCL_SECURE_NO_WARNINGS -ID:\buildtrees\stxxl\src\53f2b75236-bdc19ed4a0.clean\include -ID:\buildtrees\stxxl\arm64-windows-rel\include /nologo /DWIN32 /D_WINDOWS /W4 /utf-8 /GR /EHsc /MP  /wd4127 /wd4290 /wd4250 /wd4512 /wd4355 -openmp /MD /O2 /Oi /Gy /DNDEBUG /Z7 /showIncludes /Fotools\CMakeFiles\stxxl_tool.dir\benchmark_sort.cpp.obj /Fdtools\CMakeFiles\stxxl_tool.dir\ /FS -c D:\buildtrees\stxxl\src\53f2b75236-bdc19ed4a0.clean\tools\benchmark_sort.cpp
D:\buildtrees\stxxl\src\53f2b75236-bdc19ed4a0.clean\include\stxxl/bits/msvc_compatibility.h(23): error C2169: 'log2': intrinsic function, cannot be defined
ninja: build stopped: subcommand failed.
```