### PR TITLE
Update msvc_compatibility.h

### DIFF
--- a/include/stxxl/bits/msvc_compatibility.h
+++ b/include/stxxl/bits/msvc_compatibility.h
@@ -15,7 +15,7 @@
 
 #include <stxxl/bits/config.h>
 
-#if STXXL_MSVC
+#if (STXXL_MSVC && _MSC_VER < 1930)
 
 #include <cmath>
 


### PR DESCRIPTION
To support Visual Studio 17 2022.
This is necessary to build STXXL on Windows systems with the last version of Visual Studio.