### PR TITLE
Add `#include <functional>`

### DIFF
--- a/include/stxxl/bits/io/wbtl_file.h
+++ b/include/stxxl/bits/io/wbtl_file.h
@@ -23,6 +23,7 @@
 #if STXXL_HAVE_WBTL_FILE
 
 #include <map>
+#include <functional>
 
 #include <stxxl/bits/io/disk_queued_file.h>
 

--- a/lib/io/request_queue_impl_1q.cpp
+++ b/lib/io/request_queue_impl_1q.cpp
@@ -14,6 +14,7 @@
  **************************************************************************/
 
 #include <algorithm>
+#include <functional>
 
 #include <stxxl/bits/config.h>
 #include <stxxl/bits/common/error_handling.h>

--- a/lib/io/request_queue_impl_qwqr.cpp
+++ b/lib/io/request_queue_impl_qwqr.cpp
@@ -14,6 +14,7 @@
  **************************************************************************/
 
 #include <algorithm>
+#include <functional>
 
 #include <stxxl/bits/common/error_handling.h>
 #include <stxxl/bits/io/request_queue_impl_qwqr.h>


### PR DESCRIPTION
Fix build errors on systems that explicitly require this